### PR TITLE
fix(bin): don't rely on user's location of `node`

### DIFF
--- a/src/bin/compilec++.js
+++ b/src/bin/compilec++.js
@@ -1,4 +1,4 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 
 const cp = require('child_process');
 const rimraf = require('rimraf');


### PR DESCRIPTION
This uses the `env` command instead, and thus more portable (e.g. if you use nvm)

fixes https://github.com/xtuc/c-webpack-demo/issues/1